### PR TITLE
Two finger rotation gesture support + updatedCallback

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,9 +28,22 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  final controller = CropController(aspectRatio: 1000 / 667.0);
+  var controller;
   double _rotation = 0;
   CropShape shape = CropShape.box;
+
+  @override
+  void initState() {
+    super.initState();
+
+    controller = CropController(
+        aspectRatio: 1000 / 667.0,
+        updatedCallback: () {
+          setState(() {
+            _rotation = controller.rotation;
+          });
+        });
+  }
 
   void _cropImage() async {
     final pixelRatio = MediaQuery.of(context).devicePixelRatio;
@@ -135,11 +148,10 @@ class _MyHomePageState extends State<MyHomePage> {
                 icon: Icon(Icons.undo),
                 tooltip: 'Undo',
                 onPressed: () {
-                  controller.rotation = 0;
-                  controller.scale = 1;
-                  controller.offset = Offset.zero;
                   setState(() {
-                    _rotation = 0;
+                    controller.rotation = 0.0;
+                    controller.scale = 1;
+                    controller.offset = Offset.zero;
                   });
                 },
               ),
@@ -151,8 +163,8 @@ class _MyHomePageState extends State<MyHomePage> {
                   child: Slider(
                     divisions: 361,
                     value: _rotation,
-                    min: -180,
-                    max: 180,
+                    min: -360,
+                    max: 360,
                     label: '$_rotation°',
                     onChanged: (n) {
                       setState(() {


### PR DESCRIPTION
### Two finger rotation gesture support

* The image to crop can now be rotated with two fingers as well,
* Also have an`udpatedCallback` on the controller, which if provided, would get triggered with `onScaleUpdate` -- this can be used to keep the **rotation slider in sync** with the two finger rotation!

Example:
```
class _MyHomePageState extends State<MyHomePage> {
  var controller;
  double _rotation = 0;

  @override
  void initState() {
    super.initState();

    controller = CropController(
        aspectRatio: 1000 / 667.0,
        updatedCallback: () {
          // This will update the slider when rotated with two fingers
          setState(() {
            _rotation = controller.rotation;
          });
     });
  }
 
   // --- More code --
}
```

`updatedCallback` is ofcourse, optional.

![rotate_pull_request](https://user-images.githubusercontent.com/1822781/89930507-7c463580-dc28-11ea-8a95-abed2d93a342.gif)
