### PR TITLE
Add updated callback

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -100,7 +100,7 @@ class _MyHomePageState extends State<MyHomePage> {
               color: Colors.black,
               padding: EdgeInsets.all(8),
               child: Crop(
-                onChanged: (decomposition) async {
+                onChanged: (decomposition) {
                   print(
                       "Scale : ${decomposition.scale}, Rotation: ${decomposition.rotation}, translation: ${decomposition.translation}");
                 },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,14 +32,6 @@ class _MyHomePageState extends State<MyHomePage> {
   double _rotation = 0;
   CropShape shape = CropShape.box;
 
-  void initState(){
-    super.initState();
-
-    controller.onChanged = (decomposition) => 
-      print("Scale : ${decomposition.scale}, Rotation: ${decomposition.rotation}, translation: ${decomposition.translation}");
-
-  }
-
   void _cropImage() async {
     final pixelRatio = MediaQuery.of(context).devicePixelRatio;
     final cropped = await controller.crop(pixelRatio: pixelRatio);
@@ -108,6 +100,10 @@ class _MyHomePageState extends State<MyHomePage> {
               color: Colors.black,
               padding: EdgeInsets.all(8),
               child: Crop(
+                onChanged: (decomposition) async {
+                  print(
+                      "Scale : ${decomposition.scale}, Rotation: ${decomposition.rotation}, translation: ${decomposition.translation}");
+                },
                 controller: controller,
                 shape: shape,
                 child: Image.asset(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,8 +35,8 @@ class _MyHomePageState extends State<MyHomePage> {
   void initState(){
     super.initState();
 
-    controller.onChanged = (details) => 
-      print("Scale : ${details.scale}, Rotation: ${details.rotation}, translation: ${details.translation}");
+    controller.onChanged = (decomposition) => 
+      print("Scale : ${decomposition.scale}, Rotation: ${decomposition.rotation}, translation: ${decomposition.translation}");
 
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,6 +32,14 @@ class _MyHomePageState extends State<MyHomePage> {
   double _rotation = 0;
   CropShape shape = CropShape.box;
 
+  void initState(){
+    super.initState();
+
+    controller.onChanged = (details) => 
+      print("Scale : ${details.scale}, Rotation: ${details.rotation}, translation: ${details.translation}");
+
+  }
+
   void _cropImage() async {
     final pixelRatio = MediaQuery.of(context).devicePixelRatio;
     final cropped = await controller.crop(pixelRatio: pixelRatio);

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -10,16 +10,15 @@ enum CropShape {
   oval,
 }
 
-class UpdatedDetails {
+class MatrixDecomposition {
 
   final double rotation;
   final double scale;
   final Offset translation;
 
-  UpdatedDetails({this.scale, this.rotation, this.translation});
+  MatrixDecomposition({this.scale, this.rotation, this.translation});
 }
 
-typedef ChangedCallback = void Function(UpdatedDetails details);
 
 class Crop extends StatefulWidget {
   final Widget child;
@@ -213,9 +212,9 @@ class _CropState extends State<Crop> with TickerProviderStateMixin {
   }
 
   Future updateOnChanged() async{
-    if (widget.controller._onChanged != null) {
-      widget.controller._onChanged(
-        UpdatedDetails(
+    if (widget.controller.onChanged != null) {
+      widget.controller.onChanged(
+        MatrixDecomposition(
           scale: widget.controller.scale, 
           rotation: widget.controller.rotation,
           translation: widget.controller.offset)
@@ -332,7 +331,7 @@ class CropController extends ChangeNotifier {
   double _rotation = 0;
   double _scale = 1;
   Offset _offset = Offset.zero;
-  ChangedCallback _onChanged;
+  ValueChanged<MatrixDecomposition> onChanged;
 
   double get aspectRatio => _aspectRatio;
   set aspectRatio(double value) {
@@ -362,9 +361,6 @@ class CropController extends ChangeNotifier {
     ..translate(_offset.dx, _offset.dy, 0)
     ..rotateZ(_rotation)
     ..scale(_scale, _scale, 1);
-
-  set onChanged(ChangedCallback onChanged) 
-    => _onChanged = onChanged;
 
   CropController({
     double aspectRatio: 1.0,

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -11,14 +11,12 @@ enum CropShape {
 }
 
 class MatrixDecomposition {
-
   final double rotation;
   final double scale;
   final Offset translation;
 
   MatrixDecomposition({this.scale, this.rotation, this.translation});
 }
-
 
 class Crop extends StatefulWidget {
   final Widget child;
@@ -32,6 +30,7 @@ class Crop extends StatefulWidget {
   final Widget overlay;
   final bool interactive;
   final CropShape shape;
+  final ValueChanged<MatrixDecomposition> onChanged;
 
   Crop({
     Key key,
@@ -46,6 +45,7 @@ class Crop extends StatefulWidget {
     this.overlay,
     this.interactive: true,
     this.shape: CropShape.box,
+    this.onChanged,
   }) : super(key: key);
 
   @override
@@ -148,7 +148,7 @@ class _CropState extends State<Crop> with TickerProviderStateMixin {
 
     setState(() {});
 
-    updateOnChanged();
+    _handleOnChanged();
   }
 
   void _reCenterImageNoAnimation() {
@@ -196,7 +196,7 @@ class _CropState extends State<Crop> with TickerProviderStateMixin {
 
     setState(() {});
 
-    updateOnChanged();
+    _handleOnChanged();
   }
 
   void _onScaleUpdate(ScaleUpdateDetails details) {
@@ -207,19 +207,14 @@ class _CropState extends State<Crop> with TickerProviderStateMixin {
     _endOffset = widget.controller._offset;
 
     setState(() {});
-    updateOnChanged();
-
+    _handleOnChanged();
   }
 
-  Future updateOnChanged() async{
-    if (widget.controller.onChanged != null) {
-      widget.controller.onChanged(
-        MatrixDecomposition(
-          scale: widget.controller.scale, 
-          rotation: widget.controller.rotation,
-          translation: widget.controller.offset)
-        );
-    }
+  void _handleOnChanged() {
+    widget?.onChanged?.call(MatrixDecomposition(
+        scale: widget.controller.scale,
+        rotation: widget.controller.rotation,
+        translation: widget.controller.offset));
   }
 
   @override
@@ -331,7 +326,6 @@ class CropController extends ChangeNotifier {
   double _rotation = 0;
   double _scale = 1;
   Offset _offset = Offset.zero;
-  ValueChanged<MatrixDecomposition> onChanged;
 
   double get aspectRatio => _aspectRatio;
   set aspectRatio(double value) {

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -10,6 +10,17 @@ enum CropShape {
   oval,
 }
 
+class UpdatedDetails {
+
+  final double rotation;
+  final double scale;
+  final Offset translation;
+
+  UpdatedDetails({this.scale, this.rotation, this.translation});
+}
+
+typedef ChangedCallback = void Function(UpdatedDetails details);
+
 class Crop extends StatefulWidget {
   final Widget child;
   final CropController controller;
@@ -137,6 +148,8 @@ class _CropState extends State<Crop> with TickerProviderStateMixin {
     _controller.forward();
 
     setState(() {});
+
+    updateOnChanged();
   }
 
   void _reCenterImageNoAnimation() {
@@ -183,6 +196,8 @@ class _CropState extends State<Crop> with TickerProviderStateMixin {
     widget.controller._offset = _endOffset;
 
     setState(() {});
+
+    updateOnChanged();
   }
 
   void _onScaleUpdate(ScaleUpdateDetails details) {
@@ -193,6 +208,19 @@ class _CropState extends State<Crop> with TickerProviderStateMixin {
     _endOffset = widget.controller._offset;
 
     setState(() {});
+    updateOnChanged();
+
+  }
+
+  Future updateOnChanged() async{
+    if (widget.controller._onChanged != null) {
+      widget.controller._onChanged(
+        UpdatedDetails(
+          scale: widget.controller.scale, 
+          rotation: widget.controller.rotation,
+          translation: widget.controller.offset)
+        );
+    }
   }
 
   @override
@@ -304,6 +332,7 @@ class CropController extends ChangeNotifier {
   double _rotation = 0;
   double _scale = 1;
   Offset _offset = Offset.zero;
+  ChangedCallback _onChanged;
 
   double get aspectRatio => _aspectRatio;
   set aspectRatio(double value) {
@@ -333,6 +362,9 @@ class CropController extends ChangeNotifier {
     ..translate(_offset.dx, _offset.dy, 0)
     ..rotateZ(_rotation)
     ..scale(_scale, _scale, 1);
+
+  set onChanged(ChangedCallback onChanged) 
+    => _onChanged = onChanged;
 
   CropController({
     double aspectRatio: 1.0,


### PR DESCRIPTION
> Will close the old pull request : https://github.com/xclud/flutter_crop/pull/30

Now `onChanged` callback can be specified using controller's setter:

Example:
```
void initState(){
    super.initState();

    controller.onChanged = (details){
      print("Scale : ${details.scale}, Rotation: ${details.rotation}, translation: ${details.translation}");
      setState(() => _rotation = details.rotation.roundToDouble());
    };
}
```