### PR TITLE
Add support for rotation using two finger gesture

### DIFF
--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -196,11 +196,10 @@ class _CropState extends State<Crop> with TickerProviderStateMixin {
        so using appropriate setter for rotation
        This will enable rotation using gesture
     */
-    widget.controller.rotationRads =  details.rotation;
+    widget.controller.rotationRads = details.rotation;
 
     setState(() {});
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -335,9 +334,9 @@ class CropController extends ChangeNotifier {
     _offset = value;
     notifyListeners();
   }
-  
+
   double get rotationRads => _rotation / 180.0 * pi;
-  set rotationRads(double radians){
+  set rotationRads(double radians) {
     /* Using the setter rotation, 
        and that will notify listeners as well */
     rotation = radians * 180 / pi;

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -192,12 +192,19 @@ class _CropState extends State<Crop> with TickerProviderStateMixin {
     _startOffset = widget.controller._offset;
     _endOffset = widget.controller._offset;
 
+    /* details.rotation is in radians, 
+       so using appropriate setter for rotation
+       This will enable rotation using gesture
+    */
+    widget.controller.rotationRads =  details.rotation;
+
     setState(() {});
   }
 
+
   @override
   Widget build(BuildContext context) {
-    final r = widget.controller._rotation / 180.0 * pi;
+    final r = widget.controller.rotationRads;
     final s = widget.controller._scale * widget.controller._getMinScale();
     final o = Offset.lerp(_startOffset, _endOffset, _animation.value);
 
@@ -328,10 +335,17 @@ class CropController extends ChangeNotifier {
     _offset = value;
     notifyListeners();
   }
+  
+  double get rotationRads => _rotation / 180.0 * pi;
+  set rotationRads(double radians){
+    /* Using the setter rotation, 
+       and that will notify listeners as well */
+    rotation = radians * 180 / pi;
+  }
 
   Matrix4 get transform => Matrix4.identity()
     ..translate(_offset.dx, _offset.dy, 0)
-    ..rotateZ(_rotation)
+    ..rotateZ(rotationRads)
     ..scale(_scale, _scale, 1);
 
   CropController({

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -193,17 +193,15 @@ class _CropState extends State<Crop> with TickerProviderStateMixin {
     _endOffset = widget.controller._offset;
 
     /* details.rotation is in radians, 
-       so using appropriate setter for rotation
-       This will enable rotation using gesture
-    */
-    widget.controller.rotationRads = details.rotation;
+     convert this to degress and set our rotation */
+    widget.controller.rotation = details.rotation * 180 / pi;
 
     setState(() {});
   }
 
   @override
   Widget build(BuildContext context) {
-    final r = widget.controller.rotationRads;
+    final r = widget.controller._rotation / 180.0 * pi;
     final s = widget.controller._scale * widget.controller._getMinScale();
     final o = Offset.lerp(_startOffset, _endOffset, _animation.value);
 
@@ -335,16 +333,9 @@ class CropController extends ChangeNotifier {
     notifyListeners();
   }
 
-  double get rotationRads => _rotation / 180.0 * pi;
-  set rotationRads(double radians) {
-    /* Using the setter rotation, 
-       and that will notify listeners as well */
-    rotation = radians * 180 / pi;
-  }
-
   Matrix4 get transform => Matrix4.identity()
     ..translate(_offset.dx, _offset.dy, 0)
-    ..rotateZ(rotationRads)
+    ..rotateZ(_rotation / 180.0 * pi)
     ..scale(_scale, _scale, 1);
 
   CropController({


### PR DESCRIPTION
> Will close the old PR https://github.com/xclud/flutter_crop/pull/30

The image to crop can now be rotated with two fingers gesture as well.
![rotate_gesture](https://user-images.githubusercontent.com/1822781/90039732-ad843b80-dce4-11ea-9964-6f44e507f7f0.gif)


> Currently, haven't updated the example to also sync the slider with the rotation, as it is dependent on the other PR https://github.com/xclud/flutter_crop/pull/31,
> Once both the changes are available, we can do like the following example:
> 
> ```
> void initState(){
>     super.initState();
> 
>     controller.onChanged = (details){
>       print("Scale : ${details.scale}, Rotation: ${details.rotation}, translation: ${details.translation}");
>       setState(() => _rotation = details.rotation.roundToDouble());
>     };
>   }
> ```
> 
> Note that, the min & max value of the slider will need to be in the range (-360, 360) since the rotation values can be in this range:
> 
> ```
> Slider(
>     divisions: 361,
>     value: _rotation,
>     min: -360,
>     max: 360,
>     label: '$_rotation°',
>     /* Other args */
> )
> ```
