### PR TITLE
Support rotation gesture

### DIFF
--- a/lib/src/crop.dart
+++ b/lib/src/crop.dart
@@ -71,7 +71,6 @@ class _CropState extends State<Crop> with TickerProviderStateMixin {
   Offset _previousOffset = Offset.zero;
   Offset _startOffset = Offset.zero;
   Offset _endOffset = Offset.zero;
-  double _previousRotation = 0.0;
   double _previousGestureRotation = 0.0;
 
   /// Store the pointer count (finger involved to perform scaling).
@@ -250,8 +249,7 @@ class _CropState extends State<Crop> with TickerProviderStateMixin {
 
       /* details.rotation is in radians, convert this to degrees and set
         our rotation */
-      _previousRotation =
-          widget.controller._rotation = rotationAfterCalculation;
+      widget.controller._rotation = rotationAfterCalculation;
       _previousGestureRotation = gestureRotation;
     }
 


### PR DESCRIPTION
Support continuous rotation gesture. There is an existing [one](https://github.com/xclud/flutter_crop/pull/32), however, it does not support continuous rotation gesture and very buggy. The image will be reset to the default position if the fingers are not released together.

This PR is meant to fix all the issues mentioned above.

![continuous_rotation_gesture](https://user-images.githubusercontent.com/31196825/115189993-f44eee80-a119-11eb-965c-dbdde98d5185.gif)

