### PR TITLE
Update crop_controller.dart

### DIFF
--- a/lib/src/crop_controller.dart
+++ b/lib/src/crop_controller.dart
@@ -7,10 +7,12 @@ class CropController extends ChangeNotifier {
     double aspectRatio = 1.0,
     double scale = 1.0,
     double rotation = 0,
+    Offset offset = Offset.zero
   }) {
     _aspectRatio = aspectRatio;
     _scale = scale;
     _rotation = rotation;
+    _offset = offset;
   }
   double _aspectRatio = 1;
   double _rotation = 0;


### PR DESCRIPTION
allow users to set their own offset so it will be easy to maintain in multiple image-switching scenarios.